### PR TITLE
Fix graphical issue on family screen

### DIFF
--- a/frontend/src/components/FamilyCard.tsx
+++ b/frontend/src/components/FamilyCard.tsx
@@ -10,13 +10,15 @@ interface FamilyCardProps {
   members: FamilyMember[];
   onFamilyUpdated: () => void;
   onMemberRemoved: () => void;
+  onInviteMember: () => void;
 }
 
 const FamilyCard: React.FC<FamilyCardProps> = ({ 
   family, 
   members, 
   onFamilyUpdated, 
-  onMemberRemoved 
+  onMemberRemoved,
+  onInviteMember
 }) => {
   const { user } = useAuth();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -91,6 +93,12 @@ const FamilyCard: React.FC<FamilyCardProps> = ({
             </div>
           </div>
           <div className="flex space-x-2">
+            <button
+              onClick={onInviteMember}
+              className="btn-secondary text-sm px-3 py-1"
+            >
+              Invite Member
+            </button>
             <button
               onClick={() => setIsExpanded(!isExpanded)}
               className="text-primary-600 hover:text-primary-700 text-sm font-medium"

--- a/frontend/src/pages/FamiliesPage.tsx
+++ b/frontend/src/pages/FamiliesPage.tsx
@@ -164,22 +164,14 @@ const FamiliesPage: React.FC = () => {
           ) : (
             <div className="space-y-6">
               {families.map((family) => (
-                <div key={family.id} className="relative">
-                  <FamilyCard
-                    family={family}
-                    members={familyMembers[family.id] || []}
-                    onFamilyUpdated={handleFamilyUpdated}
-                    onMemberRemoved={handleMemberRemoved}
-                  />
-                  <div className="absolute top-6 right-6">
-                    <button
-                      onClick={() => handleInviteMember(family)}
-                      className="btn-secondary text-sm px-3 py-1"
-                    >
-                      Invite Member
-                    </button>
-                  </div>
-                </div>
+                <FamilyCard
+                  key={family.id}
+                  family={family}
+                  members={familyMembers[family.id] || []}
+                  onFamilyUpdated={handleFamilyUpdated}
+                  onMemberRemoved={handleMemberRemoved}
+                  onInviteMember={() => handleInviteMember(family)}
+                />
               ))}
             </div>
           )}


### PR DESCRIPTION
Integrate 'Invite Member' button into FamilyCard to fix overlapping UI elements.

The "Invite Member" button was previously positioned absolutely over the FamilyCard, causing it to overlap with other action buttons ("View Details", "Delete") in the card's header. This PR moves the button directly into the FamilyCard's internal button group, resolving the graphical conflict and ensuring proper layout.