### PR TITLE
Fix direct link to individual ai analysis

### DIFF
--- a/frontend/src/components/AnalysisCard.tsx
+++ b/frontend/src/components/AnalysisCard.tsx
@@ -7,10 +7,11 @@ import { AIAnalysisResponse } from '../types/aiAnalysis';
 interface AnalysisCardProps {
   analysis: AIAnalysisResponse;
   onAnalysisDeleted: () => void;
+  initialExpanded?: boolean;
 }
 
-const AnalysisCard: React.FC<AnalysisCardProps> = ({ analysis, onAnalysisDeleted }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
+const AnalysisCard: React.FC<AnalysisCardProps> = ({ analysis, onAnalysisDeleted, initialExpanded = false }) => {
+  const [isExpanded, setIsExpanded] = useState(initialExpanded);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isCancelling, setIsCancelling] = useState(false);
   const [progress, setProgress] = useState<any>(null);

--- a/frontend/src/components/ScheduleExecutionHistoryModal.tsx
+++ b/frontend/src/components/ScheduleExecutionHistoryModal.tsx
@@ -76,9 +76,9 @@ const ScheduleExecutionHistoryModal: React.FC<ScheduleExecutionHistoryModalProps
     }
   };
 
-  const openAnalysisInNewTab = (analysisId: number) => {
+  const openAnalysis = (analysisId: number) => {
     // Navigate to AI Analysis page with this analysis selected
-    window.open(`/ai-analysis?analysis=${analysisId}`, '_blank');
+    window.location.href = `/ai-analysis?analysis=${analysisId}`;
   };
 
   const formatDuration = (startedAt: string, completedAt?: string) => {
@@ -301,7 +301,7 @@ const ScheduleExecutionHistoryModal: React.FC<ScheduleExecutionHistoryModalProps
                                                     {analysis.status}
                                                   </span>
                                                   <button
-                                                    onClick={() => openAnalysisInNewTab(analysis.id)}
+                                                    onClick={() => openAnalysis(analysis.id)}
                                                     className="text-blue-600 hover:text-blue-900 text-sm"
                                                   >
                                                     View Full →


### PR DESCRIPTION
Allow direct links from schedule execution history to specific AI analyses to auto-expand and scroll to the target.