### PR TITLE
Investigate model field visibility issue

### DIFF
--- a/frontend/src/components/CreateProviderModal.tsx
+++ b/frontend/src/components/CreateProviderModal.tsx
@@ -261,26 +261,52 @@ const CreateProviderModal: React.FC<CreateProviderModalProps> = ({
             </div>
 
             {/* Default Model */}
-            {availableModels.length > 0 && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Default Model
-                </label>
-                <select
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Default Model <span className="text-gray-500 text-sm font-normal">(Optional)</span>
+              </label>
+              
+              {availableModels.length > 0 ? (
+                <>
+                  <select
+                    name="default_model"
+                    value={formData.default_model}
+                    onChange={handleInputChange}
+                    className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  >
+                    <option value="">Select a model or enter custom model name below</option>
+                    {availableModels.map((model) => (
+                      <option key={model} value={model}>
+                        {model}
+                      </option>
+                    ))}
+                  </select>
+                  <div className="mt-2">
+                    <input
+                      type="text"
+                      name="default_model"
+                      value={formData.default_model}
+                      onChange={handleInputChange}
+                      placeholder="Or enter a custom model name (e.g., gpt-4, claude-3-sonnet, gemini-pro)"
+                      className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    />
+                  </div>
+                </>
+              ) : (
+                <input
+                  type="text"
                   name="default_model"
                   value={formData.default_model}
                   onChange={handleInputChange}
+                  placeholder="Enter model name (e.g., gpt-4, claude-3-sonnet, gemini-pro) - Test connection to see available models"
                   className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                >
-                  <option value="">Select a model</option>
-                  {availableModels.map((model) => (
-                    <option key={model} value={model}>
-                      {model}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
+                />
+              )}
+              
+              <p className="text-xs text-gray-500 mt-1">
+                Specify which model to use by default for this provider. If not set, the provider will use its own default model.
+              </p>
+            </div>
 
             {/* Priority */}
             <div>

--- a/frontend/src/components/EditProviderModal.tsx
+++ b/frontend/src/components/EditProviderModal.tsx
@@ -253,26 +253,52 @@ const EditProviderModal: React.FC<EditProviderModalProps> = ({
             </div>
 
             {/* Default Model */}
-            {availableModels.length > 0 && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  Default Model
-                </label>
-                <select
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Default Model <span className="text-gray-500 text-sm font-normal">(Optional)</span>
+              </label>
+              
+              {availableModels.length > 0 ? (
+                <>
+                  <select
+                    name="default_model"
+                    value={formData.default_model}
+                    onChange={handleInputChange}
+                    className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  >
+                    <option value="">Select a model or enter custom model name below</option>
+                    {availableModels.map((model) => (
+                      <option key={model} value={model}>
+                        {model}
+                      </option>
+                    ))}
+                  </select>
+                  <div className="mt-2">
+                    <input
+                      type="text"
+                      name="default_model"
+                      value={formData.default_model}
+                      onChange={handleInputChange}
+                      placeholder="Or enter a custom model name (e.g., gpt-4, claude-3-sonnet, gemini-pro)"
+                      className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    />
+                  </div>
+                </>
+              ) : (
+                <input
+                  type="text"
                   name="default_model"
                   value={formData.default_model}
                   onChange={handleInputChange}
+                  placeholder="Enter model name (e.g., gpt-4, claude-3-sonnet, gemini-pro) - Test connection to see available models"
                   className="w-full p-3 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                >
-                  <option value="">Select a model</option>
-                  {availableModels.map((model) => (
-                    <option key={model} value={model}>
-                      {model}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
+                />
+              )}
+              
+              <p className="text-xs text-gray-500 mt-1">
+                Specify which model to use by default for this provider. If not set, the provider will use its own default model.
+              </p>
+            </div>
 
             {/* Priority */}
             <div>


### PR DESCRIPTION
Make the 'Default Model' field always visible in AI Provider modals to fix its disappearing behavior.

Previously, the 'Default Model' field was conditionally rendered only when `availableModels.length > 0`. This caused it to vanish when no models were returned by the provider or during certain form interactions, preventing users from setting or viewing this optional field.