### PR TITLE
Move notification sending to background thread

### DIFF
--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -5,6 +5,7 @@ Comprehensive notification service using Apprise for multi-platform notification
 Handles notification delivery, templating, rate limiting, and queuing.
 """
 
+import asyncio
 import json
 import logging
 from datetime import datetime, timedelta


### PR DESCRIPTION
Fix `NameError: name 'asyncio' is not defined` in notification service by adding missing import.

The `notification_service.py` was attempting to use `asyncio.to_thread` to run synchronous notification methods asynchronously, but the `asyncio` module was not imported, leading to the `NameError`.